### PR TITLE
Fix genre mapping saving in train script

### DIFF
--- a/train_nn.py
+++ b/train_nn.py
@@ -121,6 +121,6 @@ for epoch in range(1, epochs + 1):
 torch.save(model.state_dict(), 'model/nn_model.pth')
 print("Training complete. Model saved to model/nn_model.pth")
 
-train_dataset = train_loader.dataset
+# Save genre mapping used during training
 with open('genre_mapping.json', 'w', encoding='utf-8') as f:
-    json.dump(train_dataset.genre_mapping, f, ensure_ascii=False, indent=2) 
+    json.dump(genre_map, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- save genre_map directly in train_nn.py

## Testing
- `python -m py_compile app.py auth.py config.py predict.py preprocess_data.py train_nn.py utils.py model/nn_model.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f4dd7953c8331b0856af632025dff